### PR TITLE
Use sizeof(*var) for malloc/realloc/memmove

### DIFF
--- a/src/lily_api_value.c
+++ b/src/lily_api_value.c
@@ -200,8 +200,8 @@ void lily_pop_value(lily_state *s)
 
 lily_container_val *new_container(uint16_t class_id, int num_values)
 {
-    lily_container_val *cv = lily_malloc(sizeof(lily_container_val));
-    cv->values = lily_malloc(num_values * sizeof(lily_value *));
+    lily_container_val *cv = lily_malloc(sizeof(*cv));
+    cv->values = lily_malloc(num_values * sizeof(*cv->values));
     cv->refcount = 0;
     cv->num_values = num_values;
     cv->extra_space = 0;
@@ -210,7 +210,7 @@ lily_container_val *new_container(uint16_t class_id, int num_values)
 
     int i;
     for (i = 0;i < num_values;i++) {
-        lily_value *elem = lily_malloc(sizeof(lily_value));
+        lily_value *elem = lily_malloc(sizeof(*elem));
         elem->flags = 0;
         cv->values[i] = elem;
     }
@@ -229,7 +229,7 @@ lily_container_val *lily_new_dynamic(void)
    Lily will close the File when it is deref'd/collected if it is open. */
 lily_file_val *lily_new_file(FILE *inner_file, const char *mode)
 {
-    lily_file_val *filev = lily_malloc(sizeof(lily_file_val));
+    lily_file_val *filev = lily_malloc(sizeof(*filev));
 
     int plus = strchr(mode, '+') != NULL;
 
@@ -245,7 +245,7 @@ lily_file_val *lily_new_file(FILE *inner_file, const char *mode)
 lily_foreign_val *lily_new_foreign(lily_state *s, uint16_t id,
         lily_destroy_func func, size_t size)
 {
-    lily_foreign_val *fv = lily_malloc(size);
+    lily_foreign_val *fv = lily_malloc(size * sizeof(*fv));
     fv->refcount = 0;
     fv->class_id = id;
     fv->destroy_func = func;
@@ -265,7 +265,7 @@ lily_container_val *lily_new_instance(uint16_t class_id, int initial)
 
 static lily_string_val *new_sv(char *buffer, int size)
 {
-    lily_string_val *sv = lily_malloc(sizeof(lily_string_val));
+    lily_string_val *sv = lily_malloc(sizeof(*sv));
     sv->refcount = 0;
     sv->string = buffer;
     sv->size = size;
@@ -278,7 +278,7 @@ static lily_string_val *new_sv(char *buffer, int size)
    will */
 lily_string_val *lily_new_string_sized(const char *source, int len)
 {
-    char *buffer = lily_malloc(len + 1);
+    char *buffer = lily_malloc((len + 1) * sizeof(*buffer));
     memcpy(buffer, source, len);
     buffer[len] = '\0';
 
@@ -290,7 +290,7 @@ lily_string_val *lily_new_string_sized(const char *source, int len)
 lily_string_val *lily_new_string(const char *source)
 {
     size_t len = strlen(source);
-    char *buffer = lily_malloc(len + 1);
+    char *buffer = lily_malloc((len + 1) * sizeof(*buffer));
     strcpy(buffer, source);
 
     return new_sv(buffer, len);
@@ -585,7 +585,7 @@ lily_value *lily_value_copy(lily_value *input)
     if (input->flags & VAL_IS_DEREFABLE)
         input->value.generic->refcount++;
 
-    lily_value *result = lily_malloc(sizeof(lily_value));
+    lily_value *result = lily_malloc(sizeof(*result));
     result->flags = input->flags;
     result->value = input->value;
 

--- a/src/lily_buffer_u16.c
+++ b/src/lily_buffer_u16.c
@@ -5,8 +5,8 @@
 
 lily_buffer_u16 *lily_new_buffer_u16(uint32_t start)
 {
-    lily_buffer_u16 *b = lily_malloc(sizeof(lily_buffer_u16));
-    b->data = lily_malloc(start * sizeof(uint16_t));
+    lily_buffer_u16 *b = lily_malloc(sizeof(*b));
+    b->data = lily_malloc(start * sizeof(*b->data));
     b->pos = 0;
     b->size = start;
     return b;
@@ -16,7 +16,7 @@ void lily_u16_write_1(lily_buffer_u16 *b, uint16_t one)
 {
     if (b->pos + 1 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     b->data[b->pos] = one;
@@ -27,7 +27,7 @@ void lily_u16_write_2(lily_buffer_u16 *b, uint16_t one, uint16_t two)
 {
     if (b->pos + 2 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     b->data[b->pos    ] = one;
@@ -40,7 +40,7 @@ void lily_u16_write_3(lily_buffer_u16 *b, uint16_t one, uint16_t two,
 {
     if (b->pos + 3 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     b->data[b->pos    ] = one;
@@ -54,7 +54,7 @@ void lily_u16_write_4(lily_buffer_u16 *b, uint16_t one, uint16_t two,
 {
     if (b->pos + 4 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     b->data[b->pos    ] = one;
@@ -69,7 +69,7 @@ void lily_u16_write_5(lily_buffer_u16 *b, uint16_t one, uint16_t two,
 {
     if (b->pos + 5 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     b->data[b->pos    ] = one;
@@ -85,7 +85,7 @@ void lily_u16_write_6(lily_buffer_u16 *b, uint16_t one, uint16_t two,
 {
     if (b->pos + 6 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     b->data[b->pos    ] = one;
@@ -103,7 +103,7 @@ void lily_u16_write_prep(lily_buffer_u16 *b, uint32_t needed)
         while ((b->pos + needed) > b->size)
             b->size *= 2;
 
-        b->data = lily_realloc(b->data, sizeof(uint16_t) * b->size);
+        b->data = lily_realloc(b->data, sizeof(*b->data) * b->size);
     }
 }
 
@@ -118,12 +118,12 @@ void lily_u16_inject(lily_buffer_u16 *b, int where, uint16_t value)
 {
     if (b->pos + 1 > b->size) {
         b->size *= 2;
-        b->data = lily_realloc(b->data, b->size * sizeof(uint16_t));
+        b->data = lily_realloc(b->data, b->size * sizeof(*b->data));
     }
 
     int move_by = b->pos - where;
 
-    memmove(b->data+where+1, b->data+where, move_by * sizeof(uint16_t));
+    memmove(b->data+where+1, b->data+where, move_by * sizeof(*b->data));
     b->pos++;
     b->data[where] = value;
 }

--- a/src/lily_expr.c
+++ b/src/lily_expr.c
@@ -35,12 +35,12 @@ static void add_save_entry(lily_expr_state *);
 
 lily_expr_state *lily_new_expr_state(void)
 {
-    lily_expr_state *es = lily_malloc(sizeof(lily_expr_state));
+    lily_expr_state *es = lily_malloc(sizeof(*es));
 
     int i;
     lily_ast *last_tree = NULL;
     for (i = 0;i < 4;i++) {
-        lily_ast *new_tree = lily_malloc(sizeof(lily_ast));
+        lily_ast *new_tree = lily_malloc(sizeof(*new_tree));
 
         new_tree->next_tree = last_tree;
         last_tree = new_tree;
@@ -85,7 +85,7 @@ void lily_free_expr_state(lily_expr_state *es)
 
 static void add_save_entry(lily_expr_state *es)
 {
-    lily_ast_save_entry *new_entry = lily_malloc(sizeof(lily_ast_save_entry));
+    lily_ast_save_entry *new_entry = lily_malloc(sizeof(*new_entry));
 
     if (es->save_chain == NULL) {
         es->save_chain = new_entry;
@@ -104,7 +104,7 @@ static void add_save_entry(lily_expr_state *es)
 
 static void add_new_tree(lily_expr_state *es)
 {
-    lily_ast *new_tree = lily_malloc(sizeof(lily_ast));
+    lily_ast *new_tree = lily_malloc(sizeof(*new_tree));
 
     new_tree->next_tree = NULL;
 

--- a/src/lily_generic_pool.c
+++ b/src/lily_generic_pool.c
@@ -6,9 +6,9 @@
 
 lily_generic_pool *lily_new_generic_pool(void)
 {
-    lily_generic_pool *gp = lily_malloc(sizeof(lily_generic_pool));
-    lily_class **cache_generics = lily_malloc(4 * sizeof(lily_class *));
-    lily_class **scope_generics = lily_malloc(4 * sizeof(lily_class *));
+    lily_generic_pool *gp = lily_malloc(sizeof(*gp));
+    lily_class **cache_generics = lily_malloc(4 * sizeof(*cache_generics));
+    lily_class **scope_generics = lily_malloc(4 * sizeof(*scope_generics));
 
     gp->cache_generics = cache_generics;
     gp->cache_size = 4;
@@ -83,7 +83,7 @@ void lily_gp_push(lily_generic_pool *gp, const char *name, int generic_pos)
         if (i + 1 == gp->cache_size) {
             gp->cache_size *= 2;
             lily_class **new_cache = lily_realloc(gp->cache_generics,
-                    gp->cache_size * sizeof(lily_class *));
+                    gp->cache_size * sizeof(*new_cache));
 
             for (i = i + 1;i < gp->cache_size;i++)
                 new_cache[i] = NULL;
@@ -95,7 +95,7 @@ void lily_gp_push(lily_generic_pool *gp, const char *name, int generic_pos)
     if (gp->scope_end == gp->scope_size) {
         gp->scope_size *= 2;
         lily_class **new_scope = lily_realloc(gp->scope_generics,
-                gp->scope_size * sizeof(lily_class *));
+                gp->scope_size * sizeof(*new_scope));
 
         gp->scope_generics = new_scope;
     }

--- a/src/lily_lexer.c
+++ b/src/lily_lexer.c
@@ -100,7 +100,7 @@ static const lily_token grp_two_eq_table[] =
 lily_lex_state *lily_new_lex_state(lily_options *options,
         lily_raiser *raiser)
 {
-    lily_lex_state *lexer = lily_malloc(sizeof(lily_lex_state));
+    lily_lex_state *lexer = lily_malloc(sizeof(*lexer));
     lexer->data = options->data;
     lexer->render_func = options->render_func;
 
@@ -109,13 +109,13 @@ lily_lex_state *lily_new_lex_state(lily_options *options,
     lexer->last_digit_start = 0;
     lexer->entry = NULL;
     lexer->raiser = raiser;
-    lexer->input_buffer = lily_malloc(128 * sizeof(char));
-    lexer->label = lily_malloc(128 * sizeof(char));
+    lexer->input_buffer = lily_malloc(128 * sizeof(*lexer->input_buffer));
+    lexer->label = lily_malloc(128 * sizeof(*lexer->label));
     lexer->ch_class = NULL;
     lexer->last_literal = NULL;
     lexer->last_integer = 0;
     lexer->docstring = NULL;
-    ch_class = lily_malloc(256 * sizeof(char));
+    ch_class = lily_malloc(256 * sizeof(*ch_class));
 
     lexer->input_pos = 0;
     lexer->input_size = 128;
@@ -244,7 +244,7 @@ static lily_lex_entry *get_entry(lily_lex_state *lexer)
 
     if (lexer->entry == NULL ||
         (lexer->entry->source != NULL && lexer->entry->next == NULL)) {
-        ret_entry = lily_malloc(sizeof(lily_lex_entry));
+        ret_entry = lily_malloc(sizeof(*ret_entry));
 
         if (lexer->entry == NULL) {
             lexer->entry = ret_entry;
@@ -276,9 +276,10 @@ static lily_lex_entry *get_entry(lily_lex_state *lexer)
         /* size + 1 isn't needed here because the input buffer's size includes
            space for the \0. */
         if (prev_entry->saved_input == NULL)
-            new_input = lily_malloc(lexer->input_size);
+            new_input = lily_malloc(lexer->input_size * sizeof(*new_input));
         else if (prev_entry->saved_input_size < lexer->input_size)
-            new_input = lily_realloc(prev_entry->saved_input, lexer->input_size);
+            new_input = lily_realloc(prev_entry->saved_input,
+                    lexer->input_size * sizeof(*new_input));
         else
             new_input = prev_entry->saved_input;
 
@@ -867,7 +868,7 @@ static void ensure_label_size(lily_lex_state *lexer, int at_least)
     while (new_size < at_least)
         new_size *= 2;
 
-    char *new_data = lily_realloc(lexer->label, new_size);
+    char *new_data = lily_realloc(lexer->label, new_size * sizeof(*new_data));
 
     lexer->label = new_data;
     lexer->label_size = new_size;
@@ -892,7 +893,7 @@ static void scan_docstring(lily_lex_state *lexer, char **ch)
             /* No checking needs to be done for a prior docstring because parser
                makes sure docstrings are always followed by a function
                definition. */
-            lexer->docstring = lily_malloc(sizeof(char) * label_pos);
+            lexer->docstring = lily_malloc(sizeof(*lexer->docstring) * label_pos);
             strcpy(lexer->docstring, lexer->label);
 
             *ch = lexer->input_buffer + i;
@@ -1334,14 +1335,14 @@ void lily_grow_lexer_buffers(lily_lex_state *lexer)
        have to check for potential overflows. */
     if (lexer->label_size == lexer->input_size) {
         char *new_label;
-        new_label = lily_realloc(lexer->label, new_size * sizeof(char));
+        new_label = lily_realloc(lexer->label, new_size * sizeof(*new_label));
 
         lexer->label = new_label;
         lexer->label_size = new_size;
     }
 
     char *new_lb;
-    new_lb = lily_realloc(lexer->input_buffer, new_size * sizeof(char));
+    new_lb = lily_realloc(lexer->input_buffer, new_size * sizeof(*new_lb));
 
     lexer->input_buffer = new_lb;
     lexer->input_size = new_size;
@@ -1406,7 +1407,7 @@ void lily_load_source(lily_lex_state *lexer, lily_lex_entry_type mode,
              mode == et_interpolation) {
         lily_lex_entry *new_entry = get_entry(lexer);
 
-        char *copy = lily_malloc(strlen(name) + 1);
+        char *copy = lily_malloc((strlen(name) + 1) * sizeof(*copy));
 
         strcpy(copy, name);
 

--- a/src/lily_library.c
+++ b/src/lily_library.c
@@ -46,7 +46,7 @@ lily_library *lily_library_load(const char *path)
         return NULL;
     }
 
-    lily_library *lib = lily_malloc(sizeof(lily_library));
+    lily_library *lib = lily_malloc(sizeof(*lib));
     lib->source = handle;
     lib->dynaload_table = (const char **)dynaload_table;
 

--- a/src/lily_msgbuf.c
+++ b/src/lily_msgbuf.c
@@ -29,9 +29,9 @@ typedef struct lily_msgbuf_ {
 
 lily_msgbuf *lily_new_msgbuf(uint32_t initial)
 {
-    lily_msgbuf *msgbuf = lily_malloc(sizeof(lily_msgbuf));
+    lily_msgbuf *msgbuf = lily_malloc(sizeof(*msgbuf));
 
-    msgbuf->message = lily_malloc(initial * sizeof(char));
+    msgbuf->message = lily_malloc(initial * sizeof(*msgbuf->message));
     msgbuf->message[0] = '\0';
     msgbuf->pos = 0;
     msgbuf->size = initial;
@@ -44,7 +44,8 @@ static void resize_msgbuf(lily_msgbuf *msgbuf, int new_size)
     while (msgbuf->size < new_size)
         msgbuf->size *= 2;
 
-    msgbuf->message = lily_realloc(msgbuf->message, msgbuf->size);
+    msgbuf->message = lily_realloc(msgbuf->message,
+            msgbuf->size * sizeof(*msgbuf->message));
 }
 
 static void add_escaped_char(lily_msgbuf *msgbuf, char ch)

--- a/src/lily_options.c
+++ b/src/lily_options.c
@@ -5,7 +5,7 @@
 
 lily_options *lily_new_options(void)
 {
-    lily_options *opt = lily_malloc(sizeof(lily_options));
+    lily_options *opt = lily_malloc(sizeof(*opt));
     opt->argc = 0;
     opt->argv = NULL;
     opt->data = stdout;

--- a/src/lily_parser.c
+++ b/src/lily_parser.c
@@ -84,7 +84,7 @@ typedef struct lily_rewind_state_
    when it shouldn't. */
 lily_state *lily_new_state(void)
 {
-    lily_parse_state *parser = lily_malloc(sizeof(lily_parse_state));
+    lily_parse_state *parser = lily_malloc(sizeof(*parser));
     parser->module_top = NULL;
     parser->module_start = NULL;
     parser->options = lily_new_options();
@@ -98,7 +98,7 @@ lily_state *lily_new_state(void)
     parser->generics = lily_new_generic_pool();
     parser->symtab = lily_new_symtab(parser->generics);
     parser->vm = lily_new_vm_state(parser->options, raiser);
-    parser->rs = lily_malloc(sizeof(lily_rewind_state));
+    parser->rs = lily_malloc(sizeof(*parser->rs));
     parser->rs->pending = 0;
 
     parser->vm->parser = parser;
@@ -391,9 +391,9 @@ static void set_module_names_by_path(lily_module_entry *module,
         const char *path)
 {
     if (path[0] == '[') {
-        module->loadname = lily_malloc(1);
+        module->loadname = lily_malloc(1 * sizeof(*module->loadname));
         module->loadname[0] = '\0';
-        module->dirname = lily_malloc(2);
+        module->dirname = lily_malloc(2 * sizeof(*module->dirname));
         strcpy(module->dirname, ".");
         module->cmp_len = 0;
     }
@@ -401,13 +401,14 @@ static void set_module_names_by_path(lily_module_entry *module,
         const char *slash = strrchr(path, LILY_PATH_CHAR);
 
         if (slash == NULL) {
-            module->dirname = lily_malloc(1);
+            module->dirname = lily_malloc(1 * sizeof(*module->dirname));
             module->dirname[0] = '\0';
             slash = path;
         }
         else {
             int bare_len = slash - path;
-            module->dirname = lily_malloc(bare_len + 1);
+            module->dirname = lily_malloc((bare_len + 1) *
+                    sizeof(*module->dirname));
 
             strncpy(module->dirname, path, bare_len);
             module->dirname[bare_len] = '\0';
@@ -422,7 +423,8 @@ static void set_module_names_by_path(lily_module_entry *module,
         if (dot == NULL)
             load_len = strlen(path);
 
-        module->loadname = lily_malloc(load_len + 1);
+        module->loadname = lily_malloc((load_len + 1) *
+                sizeof(*module->loadname));
         strncpy(module->loadname, slash, load_len);
         module->loadname[load_len] = '\0';
 
@@ -433,10 +435,10 @@ static void set_module_names_by_path(lily_module_entry *module,
 static lily_module_entry *new_module(lily_parse_state *parser, const char *path,
         const char **dynaload_table)
 {
-    lily_module_entry *module = lily_malloc(sizeof(lily_module_entry));
+    lily_module_entry *module = lily_malloc(sizeof(*module));
 
     if (path) {
-        module->path = lily_malloc(strlen(path) + 1);
+        module->path = lily_malloc((strlen(path) + 1) * sizeof(*module->path));
         strcpy(module->path, path);
 
         set_module_names_by_path(module, path);
@@ -453,8 +455,8 @@ static lily_module_entry *new_module(lily_parse_state *parser, const char *path,
     if (dynaload_table && dynaload_table[0][0]) {
         unsigned char cid_count = dynaload_table[0][0];
 
-        module->cid_table = lily_malloc(cid_count * sizeof(uint16_t));
-        memset(module->cid_table, 0, cid_count * sizeof(uint16_t));
+        module->cid_table = lily_malloc(cid_count * sizeof(*module->cid_table));
+        memset(module->cid_table, 0, cid_count * sizeof(*module->cid_table));
     }
     else
         module->cid_table = NULL;
@@ -498,12 +500,12 @@ void lily_register_package(lily_state *s, const char *name,
 static void link_module_to(lily_module_entry *target, lily_module_entry *to_link,
         const char *as_name)
 {
-    lily_module_link *new_link = lily_malloc(sizeof(lily_module_link));
+    lily_module_link *new_link = lily_malloc(sizeof(*new_link));
     char *link_name;
     if (as_name == NULL)
         link_name = NULL;
     else {
-        link_name = lily_malloc(strlen(as_name) + 1);
+        link_name = lily_malloc((strlen(as_name) + 1) * sizeof(*link_name));
         strcpy(link_name, as_name);
     }
 

--- a/src/lily_pkg_builtin.c
+++ b/src/lily_pkg_builtin.c
@@ -285,8 +285,8 @@ static const char follower_table[256] =
 
 static lily_string_val *make_sv(lily_state *s, int size)
 {
-    lily_string_val *new_sv = lily_malloc(sizeof(lily_string_val));
-    char *new_string = lily_malloc(sizeof(char) * size);
+    lily_string_val *new_sv = lily_malloc(sizeof(*new_sv));
+    char *new_string = lily_malloc(sizeof(*new_string) * size);
 
     new_sv->string = new_string;
     new_sv->size = size - 1;
@@ -610,7 +610,7 @@ void lily_builtin_File_print(lily_state *s)
 
 static lily_bytestring_val *new_sv_take(char *buffer)
 {
-    lily_bytestring_val *sv = lily_malloc(sizeof(lily_string_val));
+    lily_bytestring_val *sv = lily_malloc(sizeof(*sv));
     sv->refcount = 0;
     sv->string = buffer;
     sv->size = strlen(buffer);
@@ -641,7 +641,7 @@ void lily_builtin_File_read(lily_state *s)
         need = -1;
 
     size_t bufsize = 64;
-    char *buffer = lily_malloc(bufsize);
+    char *buffer = lily_malloc(bufsize * sizeof(*buffer));
     int pos = 0, nread;
     int nbuf = bufsize/2;
 
@@ -659,7 +659,7 @@ void lily_builtin_File_read(lily_state *s)
         if (pos >= bufsize) {
             nbuf = bufsize;
             bufsize *= 2;
-            buffer = lily_realloc(buffer, bufsize);
+            buffer = lily_realloc(buffer, bufsize * sizeof(*buffer));
         }
 
         /* Done if EOF hit (first), or got what was wanted (second). */
@@ -1334,7 +1334,7 @@ static void make_extra_space_in_list(lily_container_val *lv)
     /* There's probably room for improvement here, later on. */
     int extra = (lv->num_values + 8) >> 2;
     lv->values = lily_realloc(lv->values,
-            (lv->num_values + extra) * sizeof(lily_value *));
+            (lv->num_values + extra) * sizeof(*lv->values));
     lv->extra_space = extra;
 }
 
@@ -1386,7 +1386,7 @@ void lily_builtin_List_delete_at(lily_state *s)
     /* Shove everything leftward hide the hole from erasing the value. */
     if (pos != list_val->num_values)
         memmove(list_val->values + pos, list_val->values + pos + 1,
-                (list_val->num_values - pos) * sizeof(lily_value *));
+                (list_val->num_values - pos) * sizeof(*list_val->values));
 
     list_val->num_values--;
     list_val->extra_space++;
@@ -1496,7 +1496,7 @@ void lily_builtin_List_insert(lily_state *s)
     /* Shove everything rightward to make space for the new value. */
     if (insert_pos != list_val->num_values)
         memmove(list_val->values + insert_pos + 1, list_val->values + insert_pos,
-                (list_val->num_values - insert_pos) * sizeof(lily_value *));
+                (list_val->num_values - insert_pos) * sizeof(*list_val->values));
 
     list_val->values[insert_pos] = lily_value_copy(insert_value);
     list_val->num_values++;
@@ -1732,7 +1732,7 @@ void lily_builtin_List_shift(lily_state *s)
     if (list_val->num_values != 1)
         memmove(list_val->values, list_val->values + 1,
                 (list_val->num_values - 1) *
-                sizeof(lily_value *));
+                sizeof(*list_val->values));
 
     list_val->num_values--;
     list_val->extra_space++;
@@ -1801,7 +1801,7 @@ void lily_builtin_List_unshift(lily_state *s)
 
     if (list_val->num_values != 0)
         memmove(list_val->values + 1, list_val->values,
-                list_val->num_values * sizeof(lily_value *));
+                list_val->num_values * sizeof(*list_val->values));
 
     list_val->values[0] = lily_value_copy(input_reg);
 

--- a/src/lily_raiser.c
+++ b/src/lily_raiser.c
@@ -6,8 +6,8 @@
 
 lily_raiser *lily_new_raiser(void)
 {
-    lily_raiser *raiser = lily_malloc(sizeof(lily_raiser));
-    lily_jump_link *first_jump = lily_malloc(sizeof(lily_jump_link));
+    lily_raiser *raiser = lily_malloc(sizeof(*raiser));
+    lily_jump_link *first_jump = lily_malloc(sizeof(*first_jump));
     first_jump->prev = NULL;
     first_jump->next = NULL;
 
@@ -44,7 +44,7 @@ lily_jump_link *lily_jump_setup(lily_raiser *raiser)
     if (raiser->all_jumps->next)
         raiser->all_jumps = raiser->all_jumps->next;
     else {
-        lily_jump_link *new_link = lily_malloc(sizeof(lily_jump_link));
+        lily_jump_link *new_link = lily_malloc(sizeof(*new_link));
         new_link->prev = raiser->all_jumps;
         raiser->all_jumps->next = new_link;
 

--- a/src/lily_string_pile.c
+++ b/src/lily_string_pile.c
@@ -5,9 +5,9 @@
 
 lily_string_pile *lily_new_string_pile(void)
 {
-    lily_string_pile *sp = lily_malloc(sizeof(lily_string_pile));
+    lily_string_pile *sp = lily_malloc(sizeof(*sp));
 
-    sp->buffer = lily_malloc(64);
+    sp->buffer = lily_malloc(64 * sizeof(*sp->buffer));
     sp->size = 63;
 
     return sp;
@@ -26,7 +26,8 @@ void lily_sp_insert(lily_string_pile *sp, char *new_str, uint16_t *pos)
         while (sp->size < want_size)
             sp->size *= 2;
 
-        char *new_buffer = lily_realloc(sp->buffer, sp->size);
+        char *new_buffer = lily_realloc(sp->buffer,
+                sp->size * sizeof(*new_buffer));
         sp->buffer = new_buffer;
     }
 

--- a/src/lily_symtab.c
+++ b/src/lily_symtab.c
@@ -19,7 +19,7 @@
 
 lily_symtab *lily_new_symtab(lily_generic_pool *gp)
 {
-    lily_symtab *symtab = lily_malloc(sizeof(lily_symtab));
+    lily_symtab *symtab = lily_malloc(sizeof(*symtab));
 
     symtab->main_function = NULL;
     symtab->next_class_id = 1;
@@ -219,7 +219,7 @@ void lily_free_symtab(lily_symtab *symtab)
 
 static lily_value *new_value_of_bytestring(lily_bytestring_val *bv)
 {
-    lily_value *v = lily_malloc(sizeof(lily_value));
+    lily_value *v = lily_malloc(sizeof(*v));
 
     bv->refcount++;
     v->flags = LILY_BYTESTRING_ID | VAL_IS_DEREFABLE;
@@ -229,7 +229,7 @@ static lily_value *new_value_of_bytestring(lily_bytestring_val *bv)
 
 static lily_value *new_value_of_double(double d)
 {
-    lily_value *v = lily_malloc(sizeof(lily_value));
+    lily_value *v = lily_malloc(sizeof(*v));
 
     v->flags = LILY_DOUBLE_ID;
     v->value.doubleval = d;
@@ -238,7 +238,7 @@ static lily_value *new_value_of_double(double d)
 
 static lily_value *new_value_of_integer(int64_t i)
 {
-    lily_value *v = lily_malloc(sizeof(lily_value));
+    lily_value *v = lily_malloc(sizeof(*v));
 
     v->flags = LILY_INTEGER_ID;
     v->value.integer = i;
@@ -247,7 +247,7 @@ static lily_value *new_value_of_integer(int64_t i)
 
 static lily_value *new_value_of_string(lily_string_val *sv)
 {
-    lily_value *v = lily_malloc(sizeof(lily_value));
+    lily_value *v = lily_malloc(sizeof(*v));
 
     sv->refcount++;
     v->flags = LILY_STRING_ID | VAL_IS_DEREFABLE;
@@ -402,7 +402,7 @@ static void store_function(lily_symtab *symtab, lily_var *func_var,
     func_val->line_num = func_var->line_num;
     func_val->module = module;
 
-    lily_value *v = lily_malloc(sizeof(lily_value));
+    lily_value *v = lily_malloc(sizeof(*v));
     v->flags = LILY_FUNCTION_ID;
     v->value.function = func_val;
 
@@ -454,9 +454,9 @@ static uint64_t shorthash_for_name(const char *name)
 lily_var *lily_new_raw_unlinked_var(lily_symtab *symtab, lily_type *type,
         const char *name)
 {
-    lily_var *var = lily_malloc(sizeof(lily_var));
+    lily_var *var = lily_malloc(sizeof(*var));
 
-    var->name = lily_malloc(strlen(name) + 1);
+    var->name = lily_malloc((strlen(name) + 1) * sizeof(*var->name));
     var->item_kind = ITEM_TYPE_VAR;
     var->flags = 0;
     strcpy(var->name, name);
@@ -545,8 +545,8 @@ void lily_hide_block_vars(lily_symtab *symtab, lily_var *var_stop)
    is not added to the symtab, and has no id set upon it. */
 lily_class *lily_new_raw_class(const char *name)
 {
-    lily_class *new_class = lily_malloc(sizeof(lily_class));
-    char *name_copy = lily_malloc(strlen(name) + 1);
+    lily_class *new_class = lily_malloc(sizeof(*new_class));
+    char *name_copy = lily_malloc((strlen(name) + 1) * sizeof(*name_copy));
 
     strcpy(name_copy, name);
 
@@ -737,8 +737,8 @@ static lily_module_entry *find_module(lily_module_entry *module,
 lily_prop_entry *lily_add_class_property(lily_symtab *symtab, lily_class *cls,
         lily_type *type, const char *name, int flags)
 {
-    lily_prop_entry *entry = lily_malloc(sizeof(lily_prop_entry));
-    char *entry_name = lily_malloc(strlen(name) + 1);
+    lily_prop_entry *entry = lily_malloc(sizeof(*entry));
+    char *entry_name = lily_malloc((strlen(name) + 1) * sizeof(*entry_name));
 
     strcpy(entry_name, name);
 
@@ -771,14 +771,14 @@ lily_prop_entry *lily_add_class_property(lily_symtab *symtab, lily_class *cls,
 lily_variant_class *lily_new_variant_class(lily_symtab *symtab,
         lily_class *enum_cls, const char *name)
 {
-    lily_variant_class *variant = lily_malloc(sizeof(lily_variant_class));
+    lily_variant_class *variant = lily_malloc(sizeof(*variant));
 
     variant->item_kind = ITEM_TYPE_VARIANT;
     variant->flags = CLS_EMPTY_VARIANT;
     variant->parent = enum_cls;
     variant->build_type = NULL;
     variant->shorthash = shorthash_for_name(name);
-    variant->name = lily_malloc(strlen(name) + 1);
+    variant->name = lily_malloc((strlen(name) + 1) * sizeof(*variant->name));
     strcpy(variant->name, name);
 
     variant->cls_id = symtab->next_class_id;

--- a/src/lily_type_maker.c
+++ b/src/lily_type_maker.c
@@ -10,9 +10,9 @@
 
 lily_type_maker *lily_new_type_maker(void)
 {
-    lily_type_maker *tm = lily_malloc(sizeof(lily_type_maker));
+    lily_type_maker *tm = lily_malloc(sizeof(*tm));
 
-    tm->types = lily_malloc(sizeof(lily_type *) * 4);
+    tm->types = lily_malloc(sizeof(*tm->types) * 4);
     tm->pos = 0;
     tm->size = 4;
 
@@ -21,7 +21,7 @@ lily_type_maker *lily_new_type_maker(void)
 
 lily_type *lily_new_raw_type(lily_class *cls)
 {
-    lily_type *new_type = lily_malloc(sizeof(lily_type));
+    lily_type *new_type = lily_malloc(sizeof(*new_type));
     new_type->item_kind = ITEM_TYPE_TYPE;
     new_type->cls = cls;
     new_type->flags = 0;
@@ -39,7 +39,7 @@ void lily_tm_reserve(lily_type_maker *tm, int amount)
         while (tm->pos + amount > tm->size)
             tm->size *= 2;
 
-        tm->types = lily_realloc(tm->types, sizeof(lily_type *) * tm->size);
+        tm->types = lily_realloc(tm->types, sizeof(*tm->types) * tm->size);
     }
 }
 
@@ -53,7 +53,7 @@ void lily_tm_add(lily_type_maker *tm, lily_type *type)
 {
     if (tm->pos + 1 == tm->size) {
         tm->size *= 2;
-        tm->types = lily_realloc(tm->types, sizeof(lily_type *) * tm->size);
+        tm->types = lily_realloc(tm->types, sizeof(*tm->types) * tm->size);
     }
 
     tm->types[tm->pos] = type;
@@ -66,7 +66,7 @@ void lily_tm_insert(lily_type_maker *tm, int pos, lily_type *type)
         while (pos >= tm->size)
             tm->size *= 2;
 
-        tm->types = lily_realloc(tm->types, sizeof(lily_type *) * tm->size);
+        tm->types = lily_realloc(tm->types, sizeof(*tm->types) * tm->size);
     }
 
     tm->types[pos] = type;
@@ -126,8 +126,8 @@ static lily_type *build_real_type_for(lily_type *fake_type)
     memcpy(new_type, fake_type, sizeof(lily_type));
 
     int count = fake_type->subtype_count;
-    lily_type **new_subtypes = lily_malloc(count * sizeof(lily_type *));
-    memcpy(new_subtypes, fake_type->subtypes, count * sizeof(lily_type *));
+    lily_type **new_subtypes = lily_malloc(count * sizeof(*new_subtypes));
+    memcpy(new_subtypes, fake_type->subtypes, count * sizeof(*new_subtypes));
     new_type->subtypes = new_subtypes;
     new_type->subtype_count = count;
 

--- a/src/lily_type_system.c
+++ b/src/lily_type_system.c
@@ -33,8 +33,8 @@ if (new_size >= ts->max) \
 lily_type_system *lily_new_type_system(lily_type_maker *tm,
         lily_type *dynamic_type, lily_type *question_type)
 {
-    lily_type_system *ts = lily_malloc(sizeof(lily_type_system));
-    lily_type **types = lily_malloc(4 * sizeof(lily_type *));
+    lily_type_system *ts = lily_malloc(sizeof(*ts));
+    lily_type **types = lily_malloc(4 * sizeof(*types));
 
     ts->tm = tm;
     ts->types = types;
@@ -62,7 +62,7 @@ static void grow_types(lily_type_system *ts)
 {
     ts->max *= 2;
     ts->types = lily_realloc(ts->types,
-            sizeof(lily_type *) * ts->max);;
+            sizeof(*ts->types) * ts->max);;
 }
 
 lily_type *lily_ts_resolve_with(lily_type_system *ts, lily_type *type,

--- a/src/lily_value_stack.c
+++ b/src/lily_value_stack.c
@@ -3,9 +3,9 @@
 
 lily_value_stack *lily_new_value_stack(void)
 {
-    lily_value_stack *vs = lily_malloc(sizeof(lily_value_stack));
+    lily_value_stack *vs = lily_malloc(sizeof(*vs));
 
-    vs->data = lily_malloc(4 * sizeof(lily_value *));
+    vs->data = lily_malloc(4 * sizeof(*vs->data));
     vs->pos = 0;
     vs->size = 4;
 
@@ -16,7 +16,7 @@ void lily_vs_push(lily_value_stack *vs, lily_value *value)
 {
     if (vs->pos + 1 > vs->size) {
         vs->size *= 2;
-        vs->data = lily_realloc(vs->data, vs->size * sizeof(lily_value *));
+        vs->data = lily_realloc(vs->data, vs->size * sizeof(*vs->data));
     }
 
     vs->data[vs->pos] = value;

--- a/src/lily_vm.c
+++ b/src/lily_vm.c
@@ -110,7 +110,7 @@ static void invoke_gc(lily_vm_state *);
 lily_vm_state *lily_new_vm_state(lily_options *options,
         lily_raiser *raiser)
 {
-    lily_vm_state *vm = lily_malloc(sizeof(lily_vm_state));
+    lily_vm_state *vm = lily_malloc(sizeof(*vm));
     /* Starting gc options are completely arbitrary. */
     vm->gc_threshold = 100;
     vm->gc_multiplier = 4;
@@ -136,7 +136,7 @@ lily_vm_state *lily_new_vm_state(lily_options *options,
     vm->include_last_frame_in_trace = 1;
     vm->options = options;
 
-    lily_vm_catch_entry *catch_entry = lily_malloc(sizeof(lily_vm_catch_entry));
+    lily_vm_catch_entry *catch_entry = lily_malloc(sizeof(*catch_entry));
     catch_entry->prev = NULL;
     catch_entry->next = NULL;
 
@@ -473,7 +473,7 @@ void lily_value_tag(lily_vm_state *vm, lily_value *v)
         vm->gc_spare_entries = vm->gc_spare_entries->next;
     }
     else
-        new_entry = lily_malloc(sizeof(lily_gc_entry));
+        new_entry = lily_malloc(sizeof(*new_entry));
 
     new_entry->value.gc_generic = v->value.gc_generic;
     new_entry->last_pass = 0;
@@ -528,14 +528,14 @@ static void grow_vm_registers(lily_vm_state *vm, int register_need)
     while (size < register_need);
 
     new_regs = lily_realloc(vm->regs_from_main, size *
-            sizeof(lily_value *));
+            sizeof(*new_regs));
 
     vm->regs_from_main = new_regs;
 
     /* Now create the registers as a bunch of empty values, to be filled in
        whenever they are needed. */
     for (;i < size;i++) {
-        lily_value *v = lily_malloc(sizeof(lily_value));
+        lily_value *v = lily_malloc(sizeof(*v));
         v->flags = 0;
 
         new_regs[i] = v;
@@ -632,7 +632,7 @@ TYPE_FN(push, GROW_CHECK, vm->regs_from_main[frame->total_regs], frame->total_re
 
 static void add_call_frame(lily_vm_state *vm)
 {
-    lily_call_frame *new_frame = lily_malloc(sizeof(lily_call_frame));
+    lily_call_frame *new_frame = lily_malloc(sizeof(*new_frame));
 
     /* This intentionally doesn't set anything but prev and next because the
        caller will have proper values for those. */
@@ -648,7 +648,7 @@ static void add_call_frame(lily_vm_state *vm)
 
 static void add_catch_entry(lily_vm_state *vm)
 {
-    lily_vm_catch_entry *new_entry = lily_malloc(sizeof(lily_vm_catch_entry));
+    lily_vm_catch_entry *new_entry = lily_malloc(sizeof(*new_entry));
 
     vm->catch_chain->next = new_entry;
     new_entry->next = NULL;
@@ -1193,7 +1193,7 @@ static void do_o_dynamic_cast(lily_vm_state *vm, uint16_t *code)
    value is given a ref increase. */
 static lily_value *make_cell_from(lily_value *value)
 {
-    lily_value *result = lily_malloc(sizeof(lily_value));
+    lily_value *result = lily_malloc(sizeof(*result));
     *result = *value;
     result->cell_refcount = 1;
     if (value->flags & VAL_IS_DEREFABLE)
@@ -1205,7 +1205,7 @@ static lily_value *make_cell_from(lily_value *value)
 /* This clones the data inside of 'to_copy'. */
 static lily_function_val *new_function_copy(lily_function_val *to_copy)
 {
-    lily_function_val *f = lily_malloc(sizeof(lily_function_val));
+    lily_function_val *f = lily_malloc(sizeof(*f));
 
     *f = *to_copy;
     f->refcount = 0;
@@ -1224,7 +1224,7 @@ static lily_value **do_o_create_closure(lily_vm_state *vm, uint16_t *code)
 
     lily_function_val *closure_func = new_function_copy(last_call);
 
-    lily_value **upvalues = lily_malloc(sizeof(lily_value *) * count);
+    lily_value **upvalues = lily_malloc(sizeof(*upvalues) * count);
 
     /* Cells are initially NULL so that o_set_upvalue knows to copy a new value
        into a cell. */
@@ -1248,7 +1248,7 @@ static void copy_upvalues(lily_function_val *target, lily_function_val *source)
     lily_value **source_upvalues = source->upvalues;
     int count = source->num_upvalues;
 
-    lily_value **new_upvalues = lily_malloc(sizeof(lily_value *) * count);
+    lily_value **new_upvalues = lily_malloc(sizeof(*new_upvalues) * count);
     lily_value *up;
     int i;
 
@@ -1697,7 +1697,7 @@ void lily_vm_ensure_class_table(lily_vm_state *vm, int size)
             vm->class_count *= 2;
 
         vm->class_table = lily_realloc(vm->class_table,
-                sizeof(lily_class *) * vm->class_count);
+                sizeof(*vm->class_table) * vm->class_count);
     }
 
     /* For the first pass, make sure the spots for Exception and its built-in

--- a/src/st.c
+++ b/src/st.c
@@ -61,7 +61,7 @@ static long primes[] =
         bin_pos = hash_val % table->num_bins;\
     }\
     \
-    entry = lily_malloc(sizeof(lily_hash_entry));\
+    entry = lily_malloc(sizeof(*entry));\
     \
     entry->boxed_key = lily_value_copy(key_box); \
     entry->raw_key = key_raw; \
@@ -105,16 +105,15 @@ static lily_hash_val *new_table_sized(int size, int (*compare_fn)(),
 
     size = new_size(size); /* round up to prime number */
 
-    tbl = lily_malloc(sizeof(lily_hash_val));
+    tbl = lily_malloc(sizeof(*tbl));
     tbl->refcount = 0;
     tbl->iter_count = 0;
     tbl->compare_fn = compare_fn;
     tbl->hash_fn = hash_fn;
     tbl->num_entries = 0;
     tbl->num_bins = size;
-    tbl->bins =
-            (lily_hash_entry **)lily_malloc(size * sizeof(lily_hash_entry *));
-    memset(tbl->bins, 0, size * sizeof(lily_hash_entry *));
+    tbl->bins = lily_malloc(size * sizeof(*tbl->bins));
+    memset(tbl->bins, 0, size * sizeof(*tbl->bins));
 
     return tbl;
 }
@@ -177,9 +176,8 @@ static void rehash(lily_hash_val *table)
     unsigned int hash_val;
 
     new_num_bins = new_size(old_num_bins+1);
-    new_bins = (lily_hash_entry **)lily_malloc(
-            new_num_bins * sizeof(lily_hash_entry *));
-    memset(new_bins, 0, new_num_bins * sizeof(lily_hash_entry *));
+    new_bins = lily_malloc(new_num_bins * sizeof(*new_bins));
+    memset(new_bins, 0, new_num_bins * sizeof(*new_bins));
 
     for(i = 0; i < old_num_bins; i++) {
         ptr = table->bins[i];


### PR DESCRIPTION
This is [more future-proof](https://stackoverflow.com/questions/17258647/why-is-it-safer-to-use-sizeofpointer-in-malloc) than using `sizeof(type)`.

I did add a few `sizeof(*var)` multiplications when they appeared to be missing, so I'd recommend taking a second look at this before merging.