### PR TITLE
Fix remaining reference to old Python tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(WITH_SANDBOX)
     add_subdirectory(sandbox)
 endif(WITH_SANDBOX)
 
-set(TEST_COMMAND cd .. && python pre-commit-hook.py --verbose)
+set(TEST_COMMAND cd .. && ./pre-commit-tests)
 add_custom_target(check ${CMAKE_CTEST_COMMAND}
   COMMAND ${TEST_COMMAND}
   DEPENDS lily VERBATIM)


### PR DESCRIPTION
This test command no longer exists; switch it to the new one.