### PR TITLE
Add missing #include <stdarg.h>

### DIFF
--- a/src/lily.h
+++ b/src/lily.h
@@ -1,6 +1,7 @@
 #ifndef LILY_H
 # define LILY_H
 
+# include <stdarg.h>
 # include <stdint.h>
 # include <stdio.h>
 


### PR DESCRIPTION
Found by clang. va_list is used here in a function prototype, so stdarg.h is needed.