### PR TITLE
Importing files from parent directory

### DIFF
--- a/src/lily_lexer.c
+++ b/src/lily_lexer.c
@@ -1131,7 +1131,7 @@ void lily_scan_import_path(lily_lex_state *lexer, char *path)
     int found_first_token = 0;
 
     while (1) {
-        if(lexer->token == tk_three_dots) {
+        if(lexer->token == tk_two_dots) {
             *path = '.';
             path++;
             *path = '.';
@@ -1144,7 +1144,7 @@ void lily_scan_import_path(lily_lex_state *lexer, char *path)
             path += strlen(lexer->label);
         } else {
             if(!found_first_token)
-                lily_raise_syn(lexer->raiser, "Expected ., ... or word, not '%s'.", tokname(lexer->token));
+                lily_raise_syn(lexer->raiser, "Expected ., .. or word, not '%s'.", tokname(lexer->token));
         }
 
         found_first_token = 1;
@@ -1374,8 +1374,7 @@ void lily_lexer(lily_lex_state *lexer)
                         token = tk_three_dots;
                     }
                     else
-                        lily_raise_syn(lexer->raiser,
-                                "'..' is not a valid token (expected 1 or 3 dots).");
+                        token = tk_two_dots;
                 }
             }
         }

--- a/src/lily_lexer.c
+++ b/src/lily_lexer.c
@@ -1126,33 +1126,45 @@ static void scan_lambda(lily_lex_state *lexer, char **source_ch)
 /* This is called by parser's import handling after having seen a word. The word
    might be all there is to the path. If so, there's nothing to do. But if
    there's a slash, then scoop that up. */
-void lily_scan_import_path(lily_lex_state *lexer)
+void lily_scan_import_path(lily_lex_state *lexer, char *path)
 {
-    int input_pos = lexer->input_pos;
-    char *iter_ch = &lexer->input_buffer[input_pos];
+    int found_first_token = 0;
 
-    if (*iter_ch != '/')
-        return;
-
-    char *label = &lexer->label[strlen(lexer->label)];
-
-    do {
-        *label = LILY_PATH_CHAR;
-        label++;
-        iter_ch++;
-        while (ident_table[(unsigned char)*iter_ch]) {
-            *label = *iter_ch;
-            label++;
-            iter_ch++;
+    while (1) {
+        if(lexer->token == tk_three_dots) {
+            *path = '.';
+            path++;
+            *path = '.';
+            path++;
+        } else if (lexer->token == tk_dot) {
+            *path = '.';
+            path++;
+        } else if(lexer->token == tk_word) {
+            strcpy(path, lexer->label);
+            path += strlen(lexer->label);
+        } else {
+            if(!found_first_token)
+                lily_raise_syn(lexer->raiser, "Expected ., ... or word, not '%s'.", tokname(lexer->token));
         }
-    } while (*iter_ch == '/');
 
-    if (*(label - 1) == LILY_PATH_CHAR) {
-        lily_raise_syn(lexer->raiser, "Import path cannot end with '/'.");
+        found_first_token = 1;
+
+        lily_lexer(lexer);
+
+        if (lexer->token == tk_divide) {
+            lily_lexer(lexer);
+            *path = LILY_PATH_CHAR;
+            path++;
+            continue;
+        }
+
+        *path = '\0';
+
+        break;
     }
 
-    *label = '\0';
-    lexer->input_pos = iter_ch - lexer->input_buffer;
+    if(*(path - 1) == LILY_PATH_CHAR)
+        lily_raise_syn(lexer->raiser, "Import path cannot end with '/'.");
 }
 
 /* The lexer reads `-1` and `+1` as negative or positive literals. Most of the

--- a/src/lily_lexer.h
+++ b/src/lily_lexer.h
@@ -134,7 +134,7 @@ void lily_rewind_lex_state(lily_lex_state *);
 void lily_grow_lexer_buffers(lily_lex_state *);
 void lily_lexer(lily_lex_state *);
 int lily_lexer_digit_rescan(lily_lex_state *);
-void lily_scan_import_path(lily_lex_state *);
+void lily_scan_import_path(lily_lex_state *, char *);
 void lily_verify_template(lily_lex_state *);
 int lily_lexer_read_content(lily_lex_state *, char **);
 

--- a/src/lily_lexer.h
+++ b/src/lily_lexer.h
@@ -72,7 +72,8 @@ typedef enum {
     tk_invalid,
     tk_end_lambda,
     tk_end_tag,
-    tk_eof
+    tk_eof,
+    tk_two_dots
 } lily_token;
 
 typedef enum {

--- a/src/lily_msgbuf.c
+++ b/src/lily_msgbuf.c
@@ -135,6 +135,7 @@ const char *lily_mb_raw(lily_msgbuf *msgbuf)
 
 void lily_mb_add(lily_msgbuf *msgbuf, const char *str)
 {
+    if (str == 0) str = "(null)";
     size_t len = strlen(str);
 
     if ((msgbuf->pos + len + 1) > msgbuf->size)

--- a/src/lily_parser.c
+++ b/src/lily_parser.c
@@ -3763,7 +3763,7 @@ static void import_handler(lily_parse_state *parser, int multi)
 
         /* The import path may include slashes. Use this to scan the path,
            because it won't allow spaces in between. */
-        char *full_path = (char *) malloc(256);
+        char full_path[256];
         lily_scan_import_path(lex, full_path);
 
         lily_module_entry *module = NULL;

--- a/src/lily_parser.c
+++ b/src/lily_parser.c
@@ -3760,13 +3760,14 @@ static void import_handler(lily_parse_state *parser, int multi)
         if (lex->token == tk_left_parenth)
             collect_import_refs(parser, &import_sym_count);
 
-        NEED_CURRENT_TOK(tk_word)
+
         /* The import path may include slashes. Use this to scan the path,
            because it won't allow spaces in between. */
-        lily_scan_import_path(lex);
+        char *full_path = (char *) malloc(256);
+        lily_scan_import_path(lex, full_path);
 
         lily_module_entry *module = NULL;
-        char *search_start = lex->label;
+        char *search_start = full_path;
         char *path_tail = strrchr(search_start, LILY_PATH_CHAR);
         /* Will the name that is going to be added conflict with something that
            has already been added? */
@@ -3779,11 +3780,11 @@ static void import_handler(lily_parse_state *parser, int multi)
                     search_start);
 
         if (path_tail == NULL)
-            module = lily_find_registered_module(symtab, lex->label);
+            module = lily_find_registered_module(symtab, full_path);
 
         /* Is there a cached version that was loaded somewhere else? */
         if (module == NULL) {
-            module = load_module(parser, lex->label);
+            module = load_module(parser, full_path);
             /* module is never NULL: load_module raises on error. */
             if (module->flags & MODULE_NOT_EXECUTED) {
                 module->flags &= ~MODULE_NOT_EXECUTED;
@@ -3791,7 +3792,6 @@ static void import_handler(lily_parse_state *parser, int multi)
             }
         }
 
-        lily_lexer(parser->lex);
         if (lex->token == tk_word && strcmp(lex->label, "as") == 0) {
             if (import_sym_count)
                 lily_raise_syn(parser->raiser,

--- a/src/lily_parser_tok_table.h
+++ b/src/lily_parser_tok_table.h
@@ -85,7 +85,8 @@ static const lily_tok_info parser_tok_table[] =
     {tk_invalid,          0          , -1},
     {tk_end_lambda,       1          , -1},
     {tk_end_tag,          1          , -1},
-    {tk_eof,              1          , -1}
+    {tk_eof,              1          , -1},
+    {tk_two_dots,         1          , -1}
 };
 
 #endif

--- a/test/fail_syntax.lily
+++ b/test/fail_syntax.lily
@@ -766,7 +766,7 @@ t.interpret_for_error("Require for loop start to be Integer.",
 
 t.interpret_for_error("Require for loop start to be Integer.",
     """\
-    SyntaxError: '..' is not a valid token (expected 1 or 3 dots).\n    \
+    SyntaxError: Unexpected token '(null)'.\n    \
         from test\/[subinterp]:1:\
     """,
     """\

--- a/test/feature_import.lily
+++ b/test/feature_import.lily
@@ -36,6 +36,14 @@ t.interpret("Check getting a var from an imported target.",
     var v = deep_target.v
     """)
 
+t.interpret("Check getting a var from a parent directory.",
+    """\
+    import ../../lily/test/import_dir/var_exporter
+
+    if var_exporter.v != 10:
+        raise Exception("Failed.")
+    """)
+
 t.interpret("Check using the type of __import__.",
     """\
     import import_dir/var_access

--- a/test/import_parent.lily
+++ b/test/import_parent.lily
@@ -1,4 +1,0 @@
-import ../../lily/test/import_dir/var_exporter
-
-if var_exporter.v != 10:
-	stderr.print("Failed!")

--- a/test/import_parent.lily
+++ b/test/import_parent.lily
@@ -1,4 +1,4 @@
-import .../.../lily/test/import_dir/var_exporter
+import ../../lily/test/import_dir/var_exporter
 
 if var_exporter.v != 10:
 	stderr.print("Failed!")

--- a/test/import_parent.lily
+++ b/test/import_parent.lily
@@ -1,0 +1,4 @@
+import .../.../lily/test/import_dir/var_exporter
+
+if var_exporter.v != 10:
+	stderr.print("Failed!")


### PR DESCRIPTION
This is my first attempt at a bigger feature for lily. This PR allows the `..` and `.` token in import paths. These tokens can be used to access the parent directory or the current directory, as can be seen in the newly added test file (not yet integrated in the other proper tests). ~~I used the three dots (instead of the usual two dots for paths) because I wasn't sure how to add a new token in the beginning but this can be changed now.~~ In order to achieve this, I rewrote the scanner for the import path, I hope it's still understandable without comments.

This patch is still in the beginning (e.g. ~~the direct call to malloc without freeing~~ and the missing comments) but I wanted to show you this and get feedback if this is a route that you want to go at all. Also, two tests are failing because of wrong line numbers in exceptions :)